### PR TITLE
Added Scala 3 derived support

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ case class Person(name: String, age: Int)
 object Person {
   implicit val rw: RW[Person] = RW.gen[Person]
 }
+
+// Scala 3 only
+case class Person(name: String, age: Int) derives RW
 ```
 
 ### Parse

--- a/core/shared/src/main/scala-3/fabric/rw/CompileRW.scala
+++ b/core/shared/src/main/scala-3/fabric/rw/CompileRW.scala
@@ -31,6 +31,8 @@ import scala.quoted._
 import scala.collection.immutable.VectorMap
 
 trait CompileRW {
+  inline final def derived[T <: Product](using inline T: Mirror.ProductOf[T]): RW[T] = gen[T]
+
   inline def gen[T <: Product](using Mirror.ProductOf[T]): RW[T] = new ClassRW[T] {
     override protected def t2Map(t: T): Map[String, Json] = toMap(t)
     override protected def map2T(map: Map[String, Json]): T = fromMap[T](map)

--- a/core/shared/src/test/scala-3/spec/RWSpecManual.scala
+++ b/core/shared/src/test/scala-3/spec/RWSpecManual.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package spec
+
+import fabric._
+import fabric.define.DefType
+import fabric.rw._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.collection.immutable.VectorMap
+
+class AutoDerivationSpec extends AnyWordSpec with Matchers {
+
+  final case class Address(city:String, state: String) derives RW
+  final case class Person(name: String, age: Int, address: Address) derives RW
+
+  "automatic derivarion" should {
+    "convert Person to Json and back" in {
+      val person = Person("Matt Hicks", 41, Address("San Jose", "California"))
+      val value = person.json
+      value should be(
+        obj(
+          "name" -> "Matt Hicks",
+          "age" -> 41,
+          "address" -> obj("city" -> "San Jose", "state" -> "California")
+        )
+      )
+      val back = value.as[Person]
+      back should be(person)
+    }
+  }
+}


### PR DESCRIPTION
I'm not 100% sure that this may be enough to add Scala 3 derivation support, as idk what will happen to non-product types, but "works on my machine™" on case classes.

Also, I saw that the tests are not split by version, so I'll wait for your instructions about how to test it.

Thanks :D